### PR TITLE
Fix .gitbook/assets image rendering on website

### DIFF
--- a/module-4-indexing-selecting-and-assigning/indexing.md
+++ b/module-4-indexing-selecting-and-assigning/indexing.md
@@ -21,7 +21,7 @@
 
 * **Selecting data based on its numerical position. Used operator - iloc**
 
-![](<../.gitbook/assets/image (1) (1).png>)
+![](https://github.com/dphi-official/Introduction-to-Pandas/blob/master/.gitbook/assets/image (1) (1).png)
 
 * **Selecting data based on its numerical position. Used operator - iloc**
 
@@ -30,12 +30,13 @@
 * **Selecting data based on its numerical position. Used operator - iloc**&#x20;
 * You can also pass **list of indexes**
 
-![](<../.gitbook/assets/image (2).png>)
+![](https://github.com/dphi-official/Introduction-to-Pandas/blob/master/.gitbook/assets/image (2).png)
 
 * Selecting data based on its numerical position. Used operator - **iloc**&#x20;
 * You can also pass **negative indexes**
 
-![](<../.gitbook/assets/image (9).png>)
+![](https://github.com/dphi-official/Introduction-to-Pandas/blob/master/.gitbook/assets/image (9).png)
+
 
 ## Label Based Selection
 
@@ -48,4 +49,5 @@
 * We will learn about its implementation on a dataset soon.&#x20;
 * Selecting data from a dataframe using column and row names/index. Used operator - loc
 
-![](<../.gitbook/assets/Screen Shot 2021-11-03 at 8.22.02 PM.png>)
+![](https://github.com/dphi-official/Introduction-to-Pandas/blob/master/.gitbook/assets/Screen Shot 2021-11-03 at 8.22.02 PM.png)
+


### PR DESCRIPTION
- **Issue**: .gitbook/assets image doesn't render on website, but, renders on github
![image](https://user-images.githubusercontent.com/13011377/168829915-4ba49911-2bfb-4931-b35a-99faa01649d5.png)
![image](https://user-images.githubusercontent.com/13011377/168830393-f2e232ed-1849-43f4-a896-5a16b00f5a4f.png)


- **Solution**:  **gitbook** is separate project and it can't understand **github** blob link.
https://stackoverflow.com/questions/38448656/why-does-the-image-display-normally-in-github-while-not-in-gitbook